### PR TITLE
code coverage and assertions

### DIFF
--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -18,6 +18,7 @@
 package org.apache.bcel.classfile;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -41,51 +42,83 @@ class ClassWithLongConstantPoolItem {
     long l = 42; // here is the key; we need a double constant value
 }
 
-public class ConstantPoolTestCase extends AbstractTestCase {
+class ConstantPoolTestCase extends AbstractTestCase {
 
-    private InstructionHandle[] getInstructionHandles(final JavaClass clazz, final ConstantPoolGen cp, final Method method) {
+    private static InstructionHandle[] getInstructionHandles(final JavaClass clazz, final ConstantPoolGen cp, final Method method) {
         final MethodGen methodGen = new MethodGen(method, clazz.getClassName(), cp);
         return methodGen.getInstructionList().getInstructionHandles();
     }
 
     @Test
-    public void testConstantToString() throws ClassNotFoundException {
+    void testConstantToString() throws ClassNotFoundException {
         final JavaClass clazz = getTestJavaClass(PACKAGE_BASE_NAME + ".data.SimpleClassWithDefaultConstructor");
         final ConstantPoolGen cp = new ConstantPoolGen(clazz.getConstantPool());
         final Method[] methods = clazz.getMethods();
         for (final Method method : methods) {
             if (method.getName().equals("<init>")) {
                 for (final InstructionHandle instructionHandle : getInstructionHandles(clazz, cp, method)) {
-                    assertNotNull(instructionHandle.getInstruction().toString(cp.getConstantPool()));
-                    // TODO Need real assertions.
-                    // System.out.println(string);
+                    final String instruction = instructionHandle.getInstruction().toString(cp.getConstantPool());
+                    assertNotNull(instruction);
+                    switch (instructionHandle.getPosition()) {
+                        case 0:
+                            assertEquals("aload_0", instruction);
+                            break;
+                        case 1:
+                            assertEquals("invokespecial java/lang/Object/<init>()V", instruction);
+                            break;
+                        case 4:
+                            assertEquals("return", instruction);
+                            break;
+                        default:
+                            break;
+                    }
                 }
             }
         }
     }
 
     @Test
-    public void testDoubleConstantWontThrowClassFormatException() throws ClassNotFoundException, IOException {
+    void testClassWithDoubleConstantPoolItem() throws ClassNotFoundException, IOException {
         try (final ClassPath cp = new ClassPath("target/test-classes/org/apache/bcel/classfile")) {
-            final JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithDoubleConstantPoolItem");
-
+            final ClassWithDoubleConstantPoolItem classWithDoubleConstantPoolItem = new ClassWithDoubleConstantPoolItem();
+            final JavaClass c = new ClassPathRepository(cp).loadClass(classWithDoubleConstantPoolItem.getClass());
+            final Field[] fields = c.getFields();
+            assertNotNull(fields);
+            assertEquals(1, fields.length);
+            assertEquals(ClassWithDoubleConstantPoolItem.class.getDeclaredFields()[0].getName(), fields[0].getName());
             final ConstantPool pool = c.getConstantPool();
-            IntStream.range(0, pool.getLength()).forEach(i -> assertDoesNotThrow(() -> pool.getConstant(i)));
+            IntStream.range(0, pool.getLength()).forEach(i -> assertDoesNotThrow(() -> {
+                final Constant constant = pool.getConstant(i);
+                if (constant instanceof ConstantDouble) {
+                    assertEquals(classWithDoubleConstantPoolItem.d, ((ConstantDouble) constant).getBytes());
+                }
+                return constant;
+            }));
         }
     }
 
     @Test
-    public void testLongConstantWontThrowClassFormatException() throws ClassNotFoundException, IOException {
+    void testClassWithLongConstantPoolItem() throws ClassNotFoundException, IOException {
         try (final ClassPath cp = new ClassPath("target/test-classes/org/apache/bcel/classfile")) {
-            final JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithLongConstantPoolItem");
-
+            final ClassWithLongConstantPoolItem classWithLongConstantPoolItem = new ClassWithLongConstantPoolItem();
+            final JavaClass c = new ClassPathRepository(cp).loadClass(classWithLongConstantPoolItem.getClass());
+            final Field[] fields = c.getFields();
+            assertNotNull(fields);
+            assertEquals(1, fields.length);
+            assertEquals(ClassWithLongConstantPoolItem.class.getDeclaredFields()[0].getName(), fields[0].getName());
             final ConstantPool pool = c.getConstantPool();
-            IntStream.range(0, pool.getLength()).forEach(i -> assertDoesNotThrow(() -> pool.getConstant(i)));
+            IntStream.range(0, pool.getLength()).forEach(i -> assertDoesNotThrow(() -> {
+                final Constant constant = pool.getConstant(i);
+                if (constant instanceof ConstantLong) {
+                    assertEquals(classWithLongConstantPoolItem.l, ((ConstantLong) constant).getBytes());
+                }
+                return constant;
+            }));
         }
     }
 
     @Test
-    public void testTooManyConstants() throws ClassNotFoundException {
+    void testTooManyConstants() throws ClassNotFoundException {
         final JavaClass clazz = getTestJavaClass(PACKAGE_BASE_NAME + ".data.SimpleClassWithDefaultConstructor");
         final ConstantPoolGen cp = new ConstantPoolGen(clazz.getConstantPool());
         int i = cp.getSize();


### PR DESCRIPTION

<html>
<body>
<!--StartFragment--><h1 style="font-weight: bold; font-size: 18pt; color: rgb(0, 0, 0); font-family: sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Apache Commons BCEL</h1>

Element | Missed Instructions | Cov. | Missed Branches | Cov. | Missed | Cxty | Missed | Lines | Missed | Methods | Missed | Classes
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Total | 36 220 of 77 636 | 53 % | 3 363 of 5 920 | 43 % | 3 853 | 6 796 | 7 313 | 15 854 | 1 698 | 3 616 | 46 | 404
org.apache.bcel.generic |   | 56 % |   | 41 % | 1 332 | 2 496 | 2 409 | 5 811 | 642 | 1 457 | 9 | 217
org.apache.bcel.verifier.structurals |   | 24 % |   | 22 % | 826 | 1 045 | 1 523 | 2 164 | 290 | 452 | 2 | 16
org.apache.bcel.classfile |   | 66 % |   | 62 % | 824 | 1 888 | 1 358 | 3 910 | 484 | 1 125 | 5 | 91
org.apache.bcel.verifier.statics |   | 41 % |   | 47 % | 357 | 567 | 620 | 1 339 | 62 | 177 | 0 | 13
org.apache.bcel.util |   | 64 % |   | 49 % | 301 | 536 | 587 | 1 601 | 98 | 235 | 8 | 35
org.apache.bcel.verifier |   | 6 % |   | 5 % | 150 | 175 | 637 | 681 | 71 | 93 | 8 | 12
org.apache.bcel |   | 85 % |   | 0 % | 32 | 52 | 116 | 270 | 26 | 46 | 4 | 6
org.apache.bcel.verifier.exc |   | 20 % |   | 25 % | 31 | 37 | 63 | 78 | 25 | 31 | 10 | 14

<div class="footer" style="margin-top: 20px; border-top: 1px solid rgb(214, 211, 206); padding-top: 2px; font-size: 8pt; color: rgb(160, 160, 160); font-family: sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>











Apache Commons BCEL
Element	Missed Instructions	Cov.	Missed Branches	Cov.	Missed	Cxty	Missed	Lines	Missed	Methods	Missed	Classes
Total	36 220 of 77 636	53 %	3 363 of 5 920	43 %	3 853	6 796	7 313	15 854	1 698	3 616	46	404
[org.apache.bcel.generic](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.generic/index.html)	9 73212 397	56 %	1 048756	41 %	1 332	2 496	2 409	5 811	642	1 457	9	217
[org.apache.bcel.verifier.structurals](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.verifier.structurals/index.html)	9 0162 881	24 %	920266	22 %	826	1 045	1 523	2 164	290	452	2	16
[org.apache.bcel.classfile](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.classfile/index.html)	5 89611 888	66 %	523874	62 %	824	1 888	1 358	3 910	484	1 125	5	91
[org.apache.bcel.verifier.statics](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.verifier.statics/index.html)	4 4743 219	41 %	411369	47 %	357	567	620	1 339	62	177	0	13
[org.apache.bcel.util](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.util/index.html)	3 1405 618	64 %	289280	49 %	301	536	587	1 601	98	235	8	35
[org.apache.bcel.verifier](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.verifier/index.html)	2 935188	6 %	155	5 %	150	175	637	681	71	93	8	12
[org.apache.bcel](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel/index.html)	8585 182	85 %		0 %	32	52	116	270	26	46	4	6
[org.apache.bcel.verifier.exc](https://github.com/nbauma109/commons-bcel/compare/org.apache.bcel.verifier.exc/index.html)		20 %		25 %	31	37	63	78	25	31	10	14