### PR TITLE
Let coverage run on JDK 11

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8 ]
+        java: [ 8, 11 ]
 
     steps:
     - uses: actions/checkout@v3.1.0
@@ -44,7 +44,7 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn -V install jacoco:report --file pom.xml --no-transfer-progress
+      run: mvn -V install jacoco:report -DdataFile=jacoco_jdk${{ matrix.java }}.exec --file pom.xml --no-transfer-progress
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Some execution paths are related to the use of modules. These execution paths can't be hit if coverage runs on JDK 8.