### PR TITLE
Add getAttribute(final byte tag) to RecordComponentInfo

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/RecordComponentInfo.java
+++ b/src/main/java/org/apache/bcel/classfile/RecordComponentInfo.java
@@ -78,6 +78,25 @@ public class RecordComponentInfo implements Node {
     }
 
     /**
+     * Gets attribute for given tag.
+     *
+     * @param <T> the attribute type.
+     * @param tag the attribute tag.
+     * @return Attribute for given tag, null if not found.
+     * Refer to {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     * @since 6.13.0
+     */
+    @SuppressWarnings("unchecked")
+    public final <T extends Attribute> T getAttribute(final byte tag) {
+        for (final Attribute attribute : getAttributes()) {
+            if (attribute.getTag() == tag) {
+                return (T) attribute;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Gets all attributes.
      *
      * @return all attributes.

--- a/src/main/java/org/apache/bcel/classfile/RecordComponentInfo.java
+++ b/src/main/java/org/apache/bcel/classfile/RecordComponentInfo.java
@@ -78,7 +78,7 @@ public class RecordComponentInfo implements Node {
     }
 
     /**
-     * Gets attribute for given tag.
+     * Gets the attribute for the given tag if present, or null if absent.
      *
      * @param <T> the attribute type.
      * @param tag the attribute tag.

--- a/src/test/java/org/apache/bcel/classfile/RecordTest.java
+++ b/src/test/java/org/apache/bcel/classfile/RecordTest.java
@@ -119,10 +119,10 @@ class RecordTest extends AbstractTest {
         assertEquals(0, firstComponent.getAttributes().length);
         assertEquals(recordAttribute.getConstantPool(), firstComponent.getConstantPool());
         assertEquals("RecordComponentInfo(aNumber,I,0):", firstComponent.toString());
-        RuntimeVisibleAnnotations ann = secondComponent.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
+        final RuntimeVisibleAnnotations ann = secondComponent.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
         assertEquals("RuntimeVisibleAnnotations:\n"
                 + "  @Ljavax/annotation/Nonnull;", ann.toString());
         assertNull(secondComponent.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS));
     }
-    
+
 }

--- a/src/test/java/org/apache/bcel/classfile/RecordTest.java
+++ b/src/test/java/org/apache/bcel/classfile/RecordTest.java
@@ -21,12 +21,14 @@ package org.apache.bcel.classfile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.bcel.AbstractTest;
+import org.apache.bcel.Const;
 import org.apache.bcel.util.SyntheticRepository;
 import org.apache.bcel.visitors.CountingVisitor;
 import org.junit.jupiter.api.Test;
@@ -111,11 +113,16 @@ class RecordTest extends AbstractTest {
                 + "  RuntimeVisibleAnnotations:\n"
                 + "  @Ljavax/annotation/Nonnull;", recordAttribute.toString());
         final RecordComponentInfo firstComponent = recordAttribute.getComponents()[0];
+        final RecordComponentInfo secondComponent = recordAttribute.getComponents()[1];
         assertEquals(5, firstComponent.getIndex());
         assertEquals(6, firstComponent.getDescriptorIndex());
         assertEquals(0, firstComponent.getAttributes().length);
         assertEquals(recordAttribute.getConstantPool(), firstComponent.getConstantPool());
         assertEquals("RecordComponentInfo(aNumber,I,0):", firstComponent.toString());
+        RuntimeVisibleAnnotations ann = secondComponent.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
+        assertEquals("RuntimeVisibleAnnotations:\n"
+                + "  @Ljavax/annotation/Nonnull;", ann.toString());
+        assertNull(secondComponent.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS));
     }
-
+    
 }

--- a/src/test/java/org/apache/bcel/classfile/RecordTest.java
+++ b/src/test/java/org/apache/bcel/classfile/RecordTest.java
@@ -113,16 +113,21 @@ class RecordTest extends AbstractTest {
                 + "  RuntimeVisibleAnnotations:\n"
                 + "  @Ljavax/annotation/Nonnull;", recordAttribute.toString());
         final RecordComponentInfo firstComponent = recordAttribute.getComponents()[0];
-        final RecordComponentInfo secondComponent = recordAttribute.getComponents()[1];
         assertEquals(5, firstComponent.getIndex());
         assertEquals(6, firstComponent.getDescriptorIndex());
         assertEquals(0, firstComponent.getAttributes().length);
         assertEquals(recordAttribute.getConstantPool(), firstComponent.getConstantPool());
         assertEquals("RecordComponentInfo(aNumber,I,0):", firstComponent.toString());
+    }
+
+    @Test
+    void testRecordComponentGetAttribute() throws ClassFormatException, IOException {
+        final JavaClass clazz = new ClassParser("src/test/resources/record/SimpleRecord.class").parse();
+        final Record recordAttribute = (Record) findAttribute("Record", clazz)[0];
+        final RecordComponentInfo secondComponent = recordAttribute.getComponents()[1];
         final RuntimeVisibleAnnotations ann = secondComponent.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
         assertEquals("RuntimeVisibleAnnotations:\n"
                 + "  @Ljavax/annotation/Nonnull;", ann.toString());
         assertNull(secondComponent.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS));
     }
-
 }


### PR DESCRIPTION
This PR aligns the API of `RecordComponentInfo` on the API of `JavaClass` / `FieldOrMethod`.

Same as we would do :

```java
Annotations visibles = javaClass.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
Annotations invisibles = javaClass.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS);
```

or :

```java
Annotations visibles = fieldOrMethod.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
Annotations invisibles = fieldOrMethod.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS);
```

add the possibility to do :

```java
Annotations visibles = recordComponentInfo.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS);
Annotations invisibles = recordComponentInfo.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS);
```

instead of less readable syntax :

```java
Annotations visibles = (Annotations) Stream.of(recordComponentInfo.getAttributes()).filter(RuntimeVisibleAnnotations.class::isInstance).findAny().orElse(null);
Annotations invisibles = (Annotations) Stream.of(recordComponentInfo.getAttributes()).filter(RuntimeInvisibleAnnotations.class::isInstance).findAny().orElse(null);
```
